### PR TITLE
add script in preprocessing which can convert jpg to tiff pyramid large image type

### DIFF
--- a/preprocessing/cvt_jpg2tiff.py
+++ b/preprocessing/cvt_jpg2tiff.py
@@ -15,7 +15,7 @@ def cvt_jpg2tiff(src_dir, dst_dir):
         filename = os.path.splitext(os.path.basename(src_file))[0]
         print(filename)
         im = pyvips.Image.new_from_file(src_file)
-        im.write_to_file(dst_file, pyramid=True, tile=True, compression="none")
+        im.write_to_file(dst_file, pyramid=True, tile=True, bigtiff=True, compression="none")
     print('Done.')
 
 if __name__ == '__main__':

--- a/preprocessing/cvt_jpg2tiff.py
+++ b/preprocessing/cvt_jpg2tiff.py
@@ -5,8 +5,7 @@
     sudo apt install libvips-tools
 
 2. install tiff-tools (ubuntu 18.04):
-    sudo apt update
-    sudo apt install libtiff-tools
+    pip install tifftools
 """
 import os
 import glob
@@ -21,7 +20,7 @@ def cvt_jpg2tiff(src_dir, dst_dir):
         dst_file = os.path.join(dst_dir, os.path.basename(src_file).replace('.jpg', '.tiff'))
 
         # convert jpg to tiff
-        cmd = 'vips im_vips2tiff' + src_file + ' ' + dst_file + ':none,tile:256x256,pyramid'
+        cmd = 'vips im_vips2tiff ' + src_file + ' ' + dst_file + ':none,tile:256x256,pyramid'
         print(cmd)
         os.system(cmd)
 

--- a/preprocessing/cvt_jpg2tiff.py
+++ b/preprocessing/cvt_jpg2tiff.py
@@ -1,17 +1,7 @@
-"""
-1. install convert:
-    https://github.com/ImageMagick/ImageMagick
-
-2. install tiff-tools (ubuntu 18.04):
-    pip install tifftools
-
-If you have size limit error, try to increase the limit in: /etc/ImageMagick-6/policy.xml
-check: https://github.com/ImageMagick/ImageMagick/issues/396#issuecomment-319569255
-
-"""
 import os
 import glob
 import sys
+import pyvips
 
 def cvt_jpg2tiff(src_dir, dst_dir):
     if not os.path.exists(dst_dir):
@@ -22,15 +12,10 @@ def cvt_jpg2tiff(src_dir, dst_dir):
         dst_file = os.path.join(dst_dir, os.path.basename(src_file).replace('.jpg', '.tiff'))
 
         # convert jpg to tiff
-
-        cmd = f'convert {src_file} -define tiff64:tile-geometry=256x256 -compress none "ptif:{dst_file}"'
-        print(cmd)
-        os.system(cmd)
-
-        # add metadata to tiff
-        cmd = 'tifftools set -y -s ImageDescription "Iscan Coreo |AppMag = 20" ' + dst_file
-        print(cmd)
-        os.system(cmd)
+        filename = os.path.splitext(os.path.basename(src_file))[0]
+        print(filename)
+        im = pyvips.Image.new_from_file(src_file)
+        im.write_to_file(dst_file, pyramid=True, tile=True, compression="none")
     print('Done.')
 
 if __name__ == '__main__':

--- a/preprocessing/cvt_jpg2tiff.py
+++ b/preprocessing/cvt_jpg2tiff.py
@@ -1,0 +1,42 @@
+"""
+1. install vips command line tool (ubuntu 18.04):
+    sudo apt update
+    sudo apt install libvips
+    sudo apt install libvips-tools
+
+2. install tiff-tools (ubuntu 18.04):
+    sudo apt update
+    sudo apt install libtiff-tools
+"""
+import os
+import glob
+import sys
+
+def cvt_jpg2tiff(src_dir, dst_dir):
+    if not os.path.exists(dst_dir):
+        os.makedirs(dst_dir)
+
+    src_files = glob.glob(os.path.join(src_dir, '*.jpg'))
+    for src_file in src_files:
+        dst_file = os.path.join(dst_dir, os.path.basename(src_file).replace('.jpg', '.tiff'))
+
+        # convert jpg to tiff
+        cmd = 'vips im_vips2tiff' + src_file + ' ' + dst_file + ':none,tile:256x256,pyramid'
+        print(cmd)
+        os.system(cmd)
+
+        # add metadata to tiff
+        cmd = 'tifftools set -y -s ImageDescription "Iscan Coreo |AppMag = 20" ' + dst_file
+        print(cmd)
+        os.system(cmd)
+    print('Done.')
+
+if __name__ == '__main__':
+    args = sys.argv
+    if len(args) != 3:
+        print('Usage: python cvt_jpg2tiff.py src_dir dst_dir')
+        sys.exit(0)
+    src_dir = args[1]
+    dst_dir = args[2]
+    cvt_jpg2tiff(src_dir, dst_dir)
+        

--- a/preprocessing/cvt_jpg2tiff.py
+++ b/preprocessing/cvt_jpg2tiff.py
@@ -1,8 +1,6 @@
 """
-1. install vips command line tool (ubuntu 18.04):
-    sudo apt update
-    sudo apt install libvips
-    sudo apt install libvips-tools
+1. install convert:
+    https://github.com/ImageMagick/ImageMagick
 
 2. install tiff-tools (ubuntu 18.04):
     pip install tifftools
@@ -20,7 +18,8 @@ def cvt_jpg2tiff(src_dir, dst_dir):
         dst_file = os.path.join(dst_dir, os.path.basename(src_file).replace('.jpg', '.tiff'))
 
         # convert jpg to tiff
-        cmd = 'vips im_vips2tiff ' + src_file + ' ' + dst_file + ':none,tile:256x256,pyramid'
+
+        cmd = f'convert {src_file} -define tiff64:tile-geometry=256x256 -compress none "ptif:{dst_file}"'
         print(cmd)
         os.system(cmd)
 

--- a/preprocessing/cvt_jpg2tiff.py
+++ b/preprocessing/cvt_jpg2tiff.py
@@ -4,6 +4,10 @@
 
 2. install tiff-tools (ubuntu 18.04):
     pip install tifftools
+
+If you have size limit error, try to increase the limit in: /etc/ImageMagick-6/policy.xml
+check: https://github.com/ImageMagick/ImageMagick/issues/396#issuecomment-319569255
+
 """
 import os
 import glob


### PR DESCRIPTION
It is not convenient to directly view a 20x digital pathology image.
`preprocessing/cvt_jpg2tiff.py` help you to convert jpg images to tiff pyramid images.
#4 
